### PR TITLE
Moved most of the Wiki home page to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 #  Open Access Button
 ========
-### Push Button. Get Research. Make Progress.
+## Push Button. Get Research. Make Progress.
 
 We all know the frustration of finding the research paper you need, but you can't afford the $40 to access it. The Open Access Button helps you get the research you want right now, and adds papers you still need to your wishlist.
+
+Following the re-launch of the Open Access Button in Open Access Week, we are working hard to build and expand in the coming months. Clear instructions for contributing will follow soon but until then, feel free to check out the Wiki and Issues to see how you can help, or email martin@openaccessbutton.org.
+
+## This Repository
 
 In this repository you will find the all the code that runs the backend of the Open Access Button. The client-side code can be found in the following repositories.
 [Firefox App](https://github.com/OAButton/oab-fxaddon)
@@ -10,6 +14,28 @@ In this repository you will find the all the code that runs the backend of the O
 [Chrome App](https://github.com/OAButton/oab-chromeaddon)
 [iOS App(Coming Soon, can you help?)](https://github.com/OAButton/iOSmobileapp)
 
-Following the re-launch of the Open Access Button in Open Access Week, we are working hard to build and expand in the coming months. Clear instructions for contributing will follow soon but until then, feel free to check out the Wiki and Issues to see how you can help, or email martin@openaccessbutton.org.
+We are use the wiki for our project management around the technical development of the Open Access Button, although at the moment that is mostly just the minutes from development calls.
+
+## OAButton Repositories
+
+First of all, we have a few different repos here:
+
+* https://github.com/OAButton/backend
+    - This is the main backend. It includes the code for the website, as well as the database of user stories that we have gathered from people.
+    - The other repos connect to this, and act as different front-ends.
+* https://github.com/OAButton/oab-fxaddon
+    - This is the Firefox addon.
+* https://github.com/OAButton/oab-chromeaddon
+    - Our Chrome (and Chromium) addon.
+* https://github.com/OAButton/androidmobileapp
+    - An Android app. This works on both phones and tablets, and is designed to be fairly modular.
+* https://github.com/OAButton/OAButton_old
+    - This is the old proof of concept bookmarklet and is no longer supported.
+
+## Development
+
+We have decided not to use a general mailing list, and have decided to work through issues here on Github. General queries and issues are best dealt with in the [backend repo](https://github.com/OAButton/backend/issues), while front-end specific issues should go into their respective repo. In addition, minutes from our development meetings are stored [here](https://github.com/OAButton/backend/wiki/Core-Tech-Meeting-Minutes) in the wiki. If you want to know what we are up to and where we are planning to go in the next while, this is a good place to look.
+
+## License
 
 All of our code is licenced under an MIT licence and all site content is licenced under a Creative Commons Attribution Licence.


### PR DESCRIPTION
I feel like having a lot of development stuff in a wiki for one repo is not effective at displaying information for possible new devs. Here, I moved most of the information - everything except for the Use Cases, basically - over to the main README.md for the backend, as that's where most people will land. There ought to be a discussion repository or a clear sign on the website that you need to go to the wiki to understand the code - for now, this is an easy way to alleviate that problem. 

I feel that the use cases can remain in the wiki as their own page, and that instead of hiding away issues as [MVP] next to them, we should put those particular points into issues under an MVP milestone. This would help people get a general idea of how close or far away the MVP is. Of course, it may be possible that all of this information is out of date. In which case, we should talk about it here. 